### PR TITLE
[🐸 Frogbot] Update version of org.webjars:bootstrap to 3.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <!-- Shared properties with plugins and version numbers across submodules-->
     <asciidoctorj.version>2.5.10</asciidoctorj.version>
     <!-- Upgrading needs UI work in WebWolf -->
-    <bootstrap.version>3.3.7</bootstrap.version>
+    <bootstrap.version>3.4.1</bootstrap.version>
     <cglib.version>3.3.0</cglib.version>
     <!-- do not update necessary for lesson -->
     <checkstyle.version>3.3.0</checkstyle.version>


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Contextual Analysis                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![medium](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | CVE-2016-10735 | Not Covered | org.webjars:bootstrap:3.3.7 | org.webjars:bootstrap 3.3.7 | [3.4.0]<br>[4.0.0-beta.2] |

</div>


### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Policies:** | sca_p |
| **Watch Name:** | shiftleft_watch |
| **Contextual Analysis:** | Not Covered |
| **Direct Dependencies:** | org.webjars:bootstrap:3.3.7 |
| **Impacted Dependency:** | org.webjars:bootstrap:3.3.7 |
| **Fixed Versions:** | [3.4.0], [4.0.0-beta.2] |
| **CVSS V3:** | 6.1 |

In Bootstrap 3.x before 3.4.0 and 4.x-beta before 4.0.0-beta.2, XSS is possible in the data-target attribute, a different vulnerability than CVE-2018-14041.


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
